### PR TITLE
Fix "integer overflow" bug.

### DIFF
--- a/algorithms/searching/binary-search/binary-search.js
+++ b/algorithms/searching/binary-search/binary-search.js
@@ -44,7 +44,7 @@ function binarySearch(items, value){
         }
         
         //recalculate middle
-        middle = Math.floor((stopIndex + startIndex)/2);    
+        middle = startIndex + Math.floor((stopIndex - startIndex)/2);    
     }
 
     //make sure it's the right value


### PR DESCRIPTION
If stopIndex+startIndex is greater than the greatest integer allowed by the language, then (stopIndex + startIndex) will overflow.
One way to fix this is to rewrite the average as:
(stopIndex + startIndex)/2 == startIndex + (stopIndex - startIndex)/2

startIndex + (stopIndex - startIndex)/2 never overflows, as it is always strictly less than stopIndex and so is any intermediate result of the computation.
