### PR TITLE
'i' and 'j' should be declared as variables.

### DIFF
--- a/algorithms/sorting/selection-sort/selection-sort.js
+++ b/algorithms/sorting/selection-sort/selection-sort.js
@@ -44,7 +44,7 @@ function swap(items, firstIndex, secondIndex){
 function selectionSort(items){
 
     var len = items.length,
-        min;
+        min, i, j;
 
     for (i=0; i < len; i++){
     


### PR DESCRIPTION
Updated to declare 'i' and 'j' as variables so they're not attached to the global scope.

Kind of nit-picky, I know, but it's standing out to me like a trailing comma or missing closing brace.
