### PR TITLE
Fixed remove bug where node has 2 children.

### DIFF
--- a/data-structures/binary-search-tree/binary-search-tree-tests.htm
+++ b/data-structures/binary-search-tree/binary-search-tree-tests.htm
@@ -107,7 +107,7 @@ YAHOO.test.BinarySearchTree = (function(){
 
         setUp: function(){
             this.tree = new BinarySearchTree();
-            this.tree.add(5);
+            this.tree.add(4);
             this.tree.add(10);
             this.tree.add(6);
         },
@@ -121,18 +121,18 @@ YAHOO.test.BinarySearchTree = (function(){
         //---------------------------------------------------------------------
     
         testRemoveFirstItem: function(){
-            this.tree.remove(5);
+            this.tree.remove(4);
             assert.areEqual(2, this.tree.size(), "There should only be two items left.");
             assert.areEqual(10, this.tree._root.value, "Root value should now be 10.");
-            assert.isFalse(this.tree.contains(5));
+            assert.isFalse(this.tree.contains(4));
         },
         
         testRemoveFirstItemToo: function(){
             this.tree.remove(10);
-            this.tree.remove(5);
+            this.tree.remove(4);
             assert.areEqual(1, this.tree.size(), "There should only be one item left.");
             assert.areEqual(6, this.tree._root.value, "Root value should now be 6.");
-            assert.isFalse(this.tree.contains(5));
+            assert.isFalse(this.tree.contains(4));
             assert.isFalse(this.tree.contains(10));
         },
         
@@ -148,15 +148,34 @@ YAHOO.test.BinarySearchTree = (function(){
             assert.isFalse(this.tree.contains(6));
         },
 
+        testRemoveAnItemWithTwoChildren: function(){
+            this.tree.add(20); // Add another child to 10.
+            this.tree.add(5);
+            this.tree.add(7);
+            this.tree.remove(10);
+
+            assert.areEqual(5, this.tree.size(), "There should only be 5 items left.");
+            assert.isFalse(this.tree.contains(10));
+        },              
+
+        testRemoveAnItemWithTwoChildrenWhereLeftSubTreeHasNoRightNodes: function(){
+            this.tree.add(20); // Add another child to 10.            
+            this.tree.remove(10);
+
+            assert.areEqual(3, this.tree.size(), "There should only be 3 items left.");
+            assert.isFalse(this.tree.contains(10));
+        },
+
         testRemoveLastAll: function(){
             this.tree.remove(6);
-            this.tree.remove(5);
+            this.tree.remove(4);
             this.tree.remove(10);
             assert.areEqual(0, this.tree.size(), "There should only be two items left.");
             assert.isFalse(this.tree.contains(6));
-            assert.isFalse(this.tree.contains(5));
+            assert.isFalse(this.tree.contains(4));
             assert.isFalse(this.tree.contains(10));            
-        }                
+        } 
+
     }));        
 
     //-------------------------------------------------------------------------

--- a/data-structures/binary-search-tree/binary-search-tree.js
+++ b/data-structures/binary-search-tree/binary-search-tree.js
@@ -265,6 +265,7 @@ BinarySearchTree.prototype = {
                         //reset pointers for new traversal
                         replacement = current.left;
                         replacementParent = current;
+
                         
                         //find the right-most node
                         while(replacement.right !== null){
@@ -272,7 +273,14 @@ BinarySearchTree.prototype = {
                             replacement = replacement.right;                            
                         }
                     
-                        replacementParent.right = replacement.left;
+
+                        if (replacementParent.right === replacement) {
+                            replacementParent.right = replacement.left;
+                        } else { 
+                            //replacement will be on the left when the left most subtree
+                            //of the node to remove has no children to the right
+                            replacementParent.left = replacement.left;
+                        }
                         
                         //assign children to the replacement
                         replacement.right = current.right;


### PR DESCRIPTION
When removing a node that has 2 children, and it's left subtree has no right descendants, the removal of the replacement from it's current position needs to be set on the replacement parents left pointer. This is due to the fact that it was found on the left pointer. Compared to the more normal condition where the left sub tree's with right children, that relationship will be found on the right pointer.
