### PR TITLE
Changed inner loop on bubble sort implementations so that they do not needlessly compare the last item to an undefined value when i is 0

### DIFF
--- a/algorithms/sorting/bubble-sort/bubble-sort-2.js
+++ b/algorithms/sorting/bubble-sort/bubble-sort-2.js
@@ -47,7 +47,7 @@ function bubbleSort(items){
         i, j;
 
     for (i=len-1; i >= 0; i--){
-        for (j=len-i; j >= 0; j--){
+        for (j=len-i-1; j >= 0; j--){
             if (items[j] < items[j-1]){
                 swap(items, j, j-1);
             }

--- a/algorithms/sorting/bubble-sort/bubble-sort.js
+++ b/algorithms/sorting/bubble-sort/bubble-sort.js
@@ -47,7 +47,7 @@ function bubbleSort(items){
         i, j, stop;
 
     for (i=0; i < len; i++){
-        for (j=0, stop=len-i; j < stop; j++){
+        for (j=0, stop=len-i-1; j < stop; j++){
             if (items[j] > items[j+1]){
                 swap(items, j, j+1);
             }


### PR DESCRIPTION
Previously the inner loop on these functions would unnecessarily compare the last value in the array to an undefined index (which happens to evaluate to false in JavaScript) on the first iteration. 

This implementation eliminates one unnecessary loop iteration and makes the algorithm more translatable to other languages where comparing a number to an empty index would cause an error.
