### PR TITLE
Update binary-search-tree.js

### DIFF
--- a/data-structures/binary-search-tree/binary-search-tree.js
+++ b/data-structures/binary-search-tree/binary-search-tree.js
@@ -266,6 +266,12 @@ BinarySearchTree.prototype = {
                         replacement = current.left;
                         replacementParent = current;
                         
+                        if (!replacement.right) {
+                            replacement.right = current.right;
+                            parent.left = replacement;
+                            break;
+                        }
+                        
                         //find the right-most node
                         while(replacement.right !== null){
                             replacementParent = replacement;


### PR DESCRIPTION
Fixes an issue caused by while(replacement.right !== null) never running, in which case replacementParent.right is destroyed and endless loops are created.
